### PR TITLE
Enhance social card plugin perf

### DIFF
--- a/packages/edykim-plugin-social-card/browser.js
+++ b/packages/edykim-plugin-social-card/browser.js
@@ -1,0 +1,51 @@
+const puppeteer = require('puppeteer')
+
+exports.setupPuppeteer = () => {
+  let browserPromise = null
+  let _browsers = null
+  let _pages = null
+
+  const initBrowsers = async ({ size, options }) => {
+    if (_pages) {
+      return
+    }
+
+    if (browserPromise) {
+      return browserPromise
+    }
+
+    browserPromise = new Promise(async (resolve, reject) => {
+      _browsers = await Promise.all(
+        [...Array(size).keys()].map(() => puppeteer.launch(options))
+      )
+      const pages = await Promise.all(_browsers.map(browser => browser.newPage()))
+      resolve(pages)
+    }).then(pages => {
+      _pages = pages
+    })
+
+    return browserPromise
+  }
+
+  const closeBrowsers = () => {
+    return _browsers
+      ? Promise.all(_browsers.map(browser => browser.close()))
+      : true
+  }
+
+  const openPage = async () => {
+    const page = _pages.shift()
+    return page
+  }
+
+  const returnPage = async page => {
+    _pages.push(page)
+  }
+
+  return {
+    initBrowsers,
+    closeBrowsers,
+    openPage,
+    returnPage,
+  }
+}

--- a/packages/edykim-plugin-social-card/job-tracker.js
+++ b/packages/edykim-plugin-social-card/job-tracker.js
@@ -1,0 +1,38 @@
+exports.setupTracker = () => {
+  let _reporter = null
+  let _jobProgress = null
+  let _total = 0
+  let _done = 0
+
+  const initProgress = ({ reporter }) => {
+    _reporter = reporter
+    _jobProgress = reporter.createProgress('generate social cards')
+    _total = 0
+    _done = 0
+  }
+
+  const jobStart = () => {
+    if (_total === 0) {
+      _jobProgress.start()
+    }
+
+    _total += 1
+    _jobProgress.total = _total
+  }
+
+  const jobEnd = () => {
+    _jobProgress.tick()
+    _done += 1
+
+    if (_done === _total) {
+      _jobProgress.done()
+      initProgress({ reporter: _reporter })
+    }
+  }
+
+  return {
+    initProgress,
+    jobStart,
+    jobEnd,
+  }
+}

--- a/packages/edykim-plugin-social-card/package-lock.json
+++ b/packages/edykim-plugin-social-card/package-lock.json
@@ -29,6 +29,14 @@
         "picomatch": "^2.0.4"
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -178,6 +186,19 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "requires": {
+        "is-extendable": "^0.1.0"
       }
     },
     "extract-zip": {
@@ -331,6 +352,17 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
+    "gray-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
+      "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
+      "requires": {
+        "js-yaml": "^3.11.0",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      }
+    },
     "has-symbol-support-x": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
@@ -385,6 +417,11 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -437,6 +474,15 @@
         "is-object": "^1.0.1"
       }
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -444,6 +490,16 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -649,6 +705,20 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -656,6 +726,11 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "timed-out": {
       "version": "4.0.1",

--- a/packages/edykim-plugin-social-card/package.json
+++ b/packages/edykim-plugin-social-card/package.json
@@ -11,6 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "gatsby-source-filesystem": "^2.1.46",
+    "gray-matter": "^4.0.2",
+    "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
     "puppeteer": "^2.0.0"
   }

--- a/packages/edykim-plugin-url/gatsby-node.js
+++ b/packages/edykim-plugin-url/gatsby-node.js
@@ -24,6 +24,9 @@ const createSlugField = (
 const createUrlField = ({ node, createNodeField }, options) => {
   const { urlHandler, urlFieldName } = options
   const url = urlHandler({ node }, { ...options })
+  if (!url) {
+    return
+  }
 
   createNodeField({
     node,

--- a/packages/gosari/config/socialCardTemplate.js
+++ b/packages/gosari/config/socialCardTemplate.js
@@ -15,7 +15,7 @@ module.exports = site => {
           word-break: keep-all;
           margin: 0;
         }
-        
+
         h1 {
           line-height: 8vw;
           font-size: 8vw;
@@ -60,7 +60,7 @@ module.exports = site => {
           margin-top: -4.5vw;
           box-shadow: 3.5vw 0 0 #ea1f63, 7vw 0 0 #dddddd;
         }
-        
+
         section {
           height: 100vh;
           display: flex;
@@ -68,12 +68,12 @@ module.exports = site => {
           justify-content: flex-start;
           align-items: center;
         }
-        
+
         section > div {
           padding-left: 3vw;
           padding-right: 3vw;
         }
-        
+
         .background {
           transform: rotate(5deg) translateY(-50vw) translateX(92vw);
           z-index: -1;
@@ -94,7 +94,7 @@ module.exports = site => {
               <h1 id="title">${title}</h1>
               ${headline ? `<h2 id="headline">${headline}</h2>` : ""}
               <p>
-                 <span>${site.title}</span> ${site.author}
+                <span>${site.title}</span> ${site.author}
               </p>
             </div>
           </section>

--- a/packages/gosari/gatsby-config.js
+++ b/packages/gosari/gatsby-config.js
@@ -104,7 +104,12 @@ module.exports = {
     {
       resolve: `@edykim/gatsby-plugin-url`,
       options: {
+        targetTypes: [`MarkdownRemark`, `SocialCard`],
         urlHandler: ({ node }, { slugFieldName }) => {
+          if (node.internal.type === `SocialCard`) {
+            return null
+          }
+
           let url = node.fields[slugFieldName]
 
           if (node.frontmatter) {
@@ -133,9 +138,6 @@ module.exports = {
       options: {
         targetNodeFilter: node => {
           return (
-            node &&
-            node.internal &&
-            node.internal.type === `MarkdownRemark` &&
             node.frontmatter &&
             node.frontmatter.type === "post" &&
             node.frontmatter.draft !== true &&

--- a/packages/gosari/package-lock.json
+++ b/packages/gosari/package-lock.json
@@ -7159,8 +7159,7 @@
     "gatsby-plugin-root-import": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-root-import/-/gatsby-plugin-root-import-2.0.5.tgz",
-      "integrity": "sha512-/yA6rFjfjiFb8D6nCjfFrrGqYQMkOt4J3u2o6s7VYEF/zpA5dw2C9ENJ5fDKkJSCbbwLiEIGVMMee3vMEip2zA==",
-      "dev": true
+      "integrity": "sha512-/yA6rFjfjiFb8D6nCjfFrrGqYQMkOt4J3u2o6s7VYEF/zpA5dw2C9ENJ5fDKkJSCbbwLiEIGVMMee3vMEip2zA=="
     },
     "gatsby-plugin-sharp": {
       "version": "2.2.7",

--- a/packages/gosari/src/templates/post.js
+++ b/packages/gosari/src/templates/post.js
@@ -14,12 +14,12 @@ import { Site } from "components/layout"
 
 export default ({ data, location, pageContext }) => {
   const post = data.markdownRemark
+  const { file: { publicURL } } = data.socialCard
   const { featuredArticles } = data
   const { previous, next } = pageContext
   const { date, title, headline } = post.frontmatter
   const {
     url,
-    socialCard: { publicURL },
   } = post.fields
 
   return (
@@ -50,6 +50,11 @@ export default ({ data, location, pageContext }) => {
 
 export const query = graphql`
   query PostQuery($slug: String!) {
+    socialCard(fields: { slug: { eq: $slug } }) {
+      file {
+        publicURL
+      }
+    }
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
       excerpt(format: PLAIN, truncate: true)
@@ -64,9 +69,6 @@ export const query = graphql`
       }
       fields {
         url
-        socialCard {
-          publicURL
-        }
       }
     }
     featuredArticles: allMarkdownRemark(


### PR DESCRIPTION
Hey @edykim! 새해복 많이 받으세요 :)

I found your neat social card plugin and dive into implementation just for fun!

It seems to be suffered to use Gatsby's great change tracking because of incorrect node dependencies (using transformer node as a data source)

This change makes the plugin as a separate transformer independent of the remark plugin, so enables cache utilization and incremental build capabilities with less code. (that's what source plugin already do)

**before:** the "generate social cards" activity took 160 ~ 180s as far as I remember

**after - clean run:** around 120s
![image](https://user-images.githubusercontent.com/9696352/73141257-670f1c80-40c5-11ea-80b9-1243fca989fc.png)

**after - second run:** skip task using build cache
![image](https://user-images.githubusercontent.com/9696352/73141245-447d0380-40c5-11ea-8331-4a43b02dd185.png)

after - also able to build incrementally :wink:

![Peek 2020-01-27 04-24](https://user-images.githubusercontent.com/9696352/73140515-00860080-40bd-11ea-98cc-5690d4d59637.gif)

The community still doesn't have a good enough thumbnail generator plugin implementation. I hope this plugin to be released to the public and contributed to the Gatsby community.

Future more:

If you kill the process while a clean build is running, Gatsby cannot recycle the cache (even if all the thumbnails have been generated).

That's because Gatsby persists its state(is also an I / O-heavy task) almost last of the lifecycle. We can better balance puppeteer and state synchronization to minimize I/O in development mode. But this is a trade-off probably not need for most cases.